### PR TITLE
Use Visual Studio build tools path, rather than VS community paths

### DIFF
--- a/run_constants.bat
+++ b/run_constants.bat
@@ -1,5 +1,11 @@
 @echo off
 set BIN_DIR="bin"
 
-if not defined VisualStudioVersion call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
+if not defined VisualStudioVersion (
+    if exist "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvars64.bat" (
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
+    ) else (
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
+    )
+)
 if not exist "%BIN_DIR%" mkdir "%BIN_DIR%"


### PR DESCRIPTION
Build only actually requires the VS Build Tools, which is a
separate package that does not install Visual Studio, but is
installed as part of the C++ support on Windows